### PR TITLE
Add domain unit tests for core entities

### DIFF
--- a/CleanArchitecture.sln
+++ b/CleanArchitecture.sln
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1EB88D85
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArchitectureTests", "tests\ArchitectureTests\ArchitectureTests.csproj", "{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DomainTests", "tests\DomainTests\DomainTests.csproj", "{5F973C1F-7CFA-4B86-8FD4-0C55C71AA43A}"
+EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{34BB3069-D5D0-4046-ACAD-A2025ED7678F}"
 EndProject
 Global
@@ -52,17 +54,21 @@ Global
 		{C699FD09-4D82-4C4B-8744-4FD3B0D60EFC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{86506D03-3746-41E7-A645-97D3633981DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{86506D03-3746-41E7-A645-97D3633981DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{86506D03-3746-41E7-A645-97D3633981DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{86506D03-3746-41E7-A645-97D3633981DB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {86506D03-3746-41E7-A645-97D3633981DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {86506D03-3746-41E7-A645-97D3633981DB}.Release|Any CPU.Build.0 = Release|Any CPU
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Release|Any CPU.Build.0 = Release|Any CPU
+                {5F973C1F-7CFA-4B86-8FD4-0C55C71AA43A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {5F973C1F-7CFA-4B86-8FD4-0C55C71AA43A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {5F973C1F-7CFA-4B86-8FD4-0C55C71AA43A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {5F973C1F-7CFA-4B86-8FD4-0C55C71AA43A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
@@ -70,11 +76,12 @@ Global
 		{166778A2-518F-47F0-BBC7-DB49C76A963C} = {64A28C1B-09AF-426E-8721-D002BE554B48}
 		{6448ADE8-34BC-4F2F-A68C-5B2D6BF4FB0B} = {64A28C1B-09AF-426E-8721-D002BE554B48}
 		{0F576D4A-156D-4626-A4D5-83DD0F6FAFE7} = {64A28C1B-09AF-426E-8721-D002BE554B48}
-		{C699FD09-4D82-4C4B-8744-4FD3B0D60EFC} = {64A28C1B-09AF-426E-8721-D002BE554B48}
-		{86506D03-3746-41E7-A645-97D3633981DB} = {64A28C1B-09AF-426E-8721-D002BE554B48}
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA} = {1EB88D85-BE1E-46DE-99A2-2F02363060AF}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {B948A3CC-9872-4612-ABD2-BB3D49671542}
-	EndGlobalSection
+                {C699FD09-4D82-4C4B-8744-4FD3B0D60EFC} = {64A28C1B-09AF-426E-8721-D002BE554B48}
+                {86506D03-3746-41E7-A645-97D3633981DB} = {64A28C1B-09AF-426E-8721-D002BE554B48}
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA} = {1EB88D85-BE1E-46DE-99A2-2F02363060AF}
+                {5F973C1F-7CFA-4B86-8FD4-0C55C71AA43A} = {1EB88D85-BE1E-46DE-99A2-2F02363060AF}
+        EndGlobalSection
+        GlobalSection(ExtensibilityGlobals) = postSolution
+                SolutionGuid = {B948A3CC-9872-4612-ABD2-BB3D49671542}
+        EndGlobalSection
 EndGlobal

--- a/tests/DomainTests/CarTests.cs
+++ b/tests/DomainTests/CarTests.cs
@@ -1,0 +1,117 @@
+using Domain.Cars;
+using Domain.Cars.Atribbutes;
+using Domain.Cars.Events;
+using SharedKernel;
+
+public class CarTests
+{
+    private readonly Faker _faker = new();
+
+    [Fact]
+    public void Constructor_ShouldInitializeProperties()
+    {
+        var marca = new Marca(_faker.Vehicle.Manufacturer()) { Id = Guid.NewGuid() };
+        var modelo = new Modelo(_faker.Vehicle.Model(), marca.Id) { Id = Guid.NewGuid(), Marca = marca };
+        var color = _faker.PickRandom<Color>();
+        var typeCar = _faker.PickRandom<TypeCar>();
+        var statusCar = _faker.PickRandom<StatusCar>();
+        var serviceCar = _faker.PickRandom<statusServiceCar>();
+        var puertas = _faker.Random.Int(2, 5);
+        var asientos = _faker.Random.Int(2, 7);
+        var cilindrada = _faker.Random.Int(1000, 5000);
+        var kilometraje = _faker.Random.Int(0, 200000);
+        var anio = _faker.Date.Past(20, DateTime.UtcNow).Year;
+        var patente = _faker.Random.AlphaNumeric(6);
+        var descripcion = _faker.Lorem.Sentence();
+        var price = _faker.Random.Decimal(1000, 100000);
+        var now = DateTime.UtcNow;
+
+        var car = new Car(
+            marca,
+            modelo,
+            color,
+            typeCar,
+            statusCar,
+            serviceCar,
+            puertas,
+            asientos,
+            cilindrada,
+            kilometraje,
+            anio,
+            patente,
+            descripcion,
+            price,
+            now);
+
+        car.Id.Should().NotBe(Guid.Empty);
+        car.Marca.Should().Be(marca);
+        car.MarcaId.Should().Be(marca.Id);
+        car.Modelo.Should().Be(modelo);
+        car.ModeloId.Should().Be(modelo.Id);
+        car.Color.Should().Be(color);
+        car.CarType.Should().Be(typeCar);
+        car.CarStatus.Should().Be(statusCar);
+        car.ServiceCar.Should().Be(serviceCar);
+        car.CantidadPuertas.Should().Be(puertas);
+        car.CantidadAsientos.Should().Be(asientos);
+        car.Cilindrada.Should().Be(cilindrada);
+        car.Kilometraje.Should().Be(kilometraje);
+        car.Año.Should().Be(anio);
+        car.Patente.Should().Be(patente);
+        car.Descripcion.Should().Be(descripcion);
+        car.Price.Should().Be(price);
+        car.CreatedAt.Should().Be(now);
+        car.UpdatedAt.Should().Be(now);
+        car.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CarErrors_ShouldReturnExpectedValues()
+    {
+        var carId = Guid.NewGuid();
+        var imageId = Guid.NewGuid();
+
+        var alreadySold = CarErrors.AlreadySold(carId);
+        alreadySold.Code.Should().Be("Cars.AlreadySold");
+        alreadySold.Description.Should().Be($"The car with Id = '{carId}' is already sold.");
+        alreadySold.Type.Should().Be(ErrorType.Problem);
+
+        var notFound = CarErrors.NotFound(carId);
+        notFound.Code.Should().Be("Cars.NotFound");
+        notFound.Description.Should().Be($"The car with the Id = '{carId}' was not found");
+        notFound.Type.Should().Be(ErrorType.NotFound);
+
+        var notAll = CarErrors.NotAllAtributes(carId);
+        notAll.Code.Should().Be("Cars.NotAllAttributes");
+        notAll.Description.Should().Be($"The car with the Id = '{carId}' was not found");
+        notAll.Type.Should().Be(ErrorType.NotFound);
+
+        var invalid = CarErrors.AtributesInvalid();
+        invalid.Code.Should().Be("Cars.AtributesInvalid");
+        invalid.Description.Should().Be("Atributes are invalid");
+        invalid.Type.Should().Be(ErrorType.NotFound);
+
+        var imageNotFound = CarErrors.ImageNotFound(imageId);
+        imageNotFound.Code.Should().Be("Cars.ImageNotFound");
+        imageNotFound.Description.Should().Be($"The car image with the Id = '{imageId}' was not found");
+        imageNotFound.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void CarEvents_ShouldContainCarId()
+    {
+        var carId = Guid.NewGuid();
+
+        var newEvent = new NewCarDomainEvent(carId);
+        newEvent.CarId.Should().Be(carId);
+
+        var soldEvent = new CarSoldDomainEvent(carId);
+        soldEvent.CarId.Should().Be(carId);
+
+        var deleteEvent = new CarDeleteDomainEvent(carId);
+        deleteEvent.CarId.Should().Be(carId);
+
+        var statusEvent = new CarChangeStatusDomainEvent(carId);
+        statusEvent.CarId.Should().Be(carId);
+    }
+}

--- a/tests/DomainTests/ClientTests.cs
+++ b/tests/DomainTests/ClientTests.cs
@@ -1,0 +1,75 @@
+using Domain.Clients;
+using Domain.Clients.Attributes;
+using Domain.Clients.Events;
+using SharedKernel;
+
+public class ClientTests
+{
+    private readonly Faker _faker = new();
+
+    [Fact]
+    public void Constructor_ShouldInitializePropertiesAndRaiseEvent()
+    {
+        var firstName = _faker.Name.FirstName();
+        var lastName = _faker.Name.LastName();
+        var dni = _faker.Random.ReplaceNumbers("########");
+        var email = _faker.Internet.Email();
+        var phone = _faker.Phone.PhoneNumber();
+        var address = _faker.Address.FullAddress();
+
+        var client = new Client(firstName, lastName, dni, email, phone, address);
+
+        client.FirstName.Should().Be(firstName);
+        client.LastName.Should().Be(lastName);
+        client.DNI.Should().Be(dni);
+        client.Email.Should().Be(email);
+        client.Phone.Should().Be(phone);
+        client.Address.Should().Be(address);
+        client.Status.Should().Be(ClientStatus.Active);
+        client.Sales.Should().BeEmpty();
+        client.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        client.DomainEvents.Should().ContainSingle();
+
+        var domainEvent = client.DomainEvents.Single().Should().BeOfType<ClientCreatedDomainEvent>().Subject;
+        domainEvent.ClientId.Should().Be(client.Id);
+        domainEvent.FullName.Should().Be($"{firstName} {lastName}");
+    }
+
+    [Fact]
+    public void ClientErrors_ShouldReturnExpectedValues()
+    {
+        var clientId = Guid.NewGuid();
+
+        var alreadySold = ClientErrors.AlreadySold(clientId);
+        alreadySold.Code.Should().Be("Clients.AlreadySold");
+        alreadySold.Description.Should().Be($"The client with Id = '{clientId}' is already sold.");
+        alreadySold.Type.Should().Be(ErrorType.Problem);
+
+        var notFound = ClientErrors.NotFound(clientId);
+        notFound.Code.Should().Be("Clients.NotFound");
+        notFound.Description.Should().Be($"The client with the Id = '{clientId}' was not found");
+        notFound.Type.Should().Be(ErrorType.NotFound);
+
+        var notAll = ClientErrors.NotAllAtributes(clientId);
+        notAll.Code.Should().Be("Clients.NotAllAttributes");
+        notAll.Description.Should().Be($"The client with the Id = '{clientId}' was not found");
+        notAll.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void ClientEvents_ShouldContainClientId()
+    {
+        var clientId = Guid.NewGuid();
+        var fullName = _faker.Name.FullName();
+
+        var created = new ClientCreatedDomainEvent(clientId, fullName);
+        created.ClientId.Should().Be(clientId);
+        created.FullName.Should().Be(fullName);
+
+        var deactivated = new ClientDeactivatedDomainEvent(clientId);
+        deactivated.ClientId.Should().Be(clientId);
+
+        var updated = new ClientUpdatedDomainEvent(clientId);
+        updated.ClientId.Should().Be(clientId);
+    }
+}

--- a/tests/DomainTests/DomainTests.csproj
+++ b/tests/DomainTests/DomainTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Bogus" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Domain\Domain.csproj" />
+    <ProjectReference Include="..\..\src\SharedKernel\SharedKernel.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/DomainTests/GlobalUsings.cs
+++ b/tests/DomainTests/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using System;
+global using System.Linq;
+global using Bogus;
+global using FluentAssertions;
+global using Xunit;

--- a/tests/DomainTests/SaleTests.cs
+++ b/tests/DomainTests/SaleTests.cs
@@ -1,0 +1,82 @@
+using Domain.Sales;
+using Domain.Sales.Attributes;
+using Domain.Sales.Events;
+using Domain.Financial.Attributes;
+using SharedKernel;
+
+public class SaleTests
+{
+    private readonly Faker _faker = new();
+
+    [Fact]
+    public void Constructor_ShouldInitializeProperties()
+    {
+        var carId = Guid.NewGuid();
+        var clientId = Guid.NewGuid();
+        var finalPrice = _faker.Random.Decimal(1000, 100000);
+        var paymentMethod = _faker.PickRandom<PaymentMethod>();
+        var contractNumber = _faker.Random.ReplaceNumbers("########");
+        var comments = _faker.Lorem.Sentence();
+
+        var sale = new Sale(carId, clientId, finalPrice, paymentMethod, contractNumber, comments);
+
+        sale.CarId.Should().Be(carId);
+        sale.ClientId.Should().Be(clientId);
+        sale.FinalPrice.Should().Be(finalPrice);
+        sale.PaymentMethod.Should().Be(paymentMethod);
+        sale.ContractNumber.Should().Be(contractNumber);
+        sale.Comments.Should().Be(comments);
+        sale.Status.Should().Be(SaleStatus.Pending);
+        sale.SaleDate.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        sale.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SaleErrors_ShouldReturnExpectedValues()
+    {
+        var saleId = Guid.NewGuid();
+
+        var alreadySold = SalesErrors.AlreadySold(saleId);
+        alreadySold.Code.Should().Be("Sales.AlreadySold");
+        alreadySold.Description.Should().Be($"The sale with Id = '{saleId}' is already sold.");
+        alreadySold.Type.Should().Be(ErrorType.Problem);
+
+        var notFound = SalesErrors.NotFound(saleId);
+        notFound.Code.Should().Be("Sales.NotFound");
+        notFound.Description.Should().Be($"The sale with the Id = '{saleId}' was not found");
+        notFound.Type.Should().Be(ErrorType.NotFound);
+
+        var quoteExpired = SalesErrors.QuoteExpired(saleId);
+        quoteExpired.Code.Should().Be("Sales.QuoteExpired");
+        quoteExpired.Description.Should().Be($"The quote with the Id = '{saleId}' was not found");
+        quoteExpired.Type.Should().Be(ErrorType.NotFound);
+
+        var notAll = SalesErrors.NotAllAtributes(saleId);
+        notAll.Code.Should().Be("Sales.NotAllAttributes");
+        notAll.Description.Should().Be($"The sale with the Id = '{saleId}' was not found");
+        notAll.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void SaleEvents_ShouldContainCorrectData()
+    {
+        var saleId = Guid.NewGuid();
+        var carId = Guid.NewGuid();
+        var clientId = Guid.NewGuid();
+        var finalPrice = _faker.Random.Decimal(1000, 10000);
+        var reason = _faker.Lorem.Sentence();
+
+        var created = new SaleCreatedDomainEvent(saleId, carId, clientId, finalPrice);
+        created.SaleId.Should().Be(saleId);
+        created.CarId.Should().Be(carId);
+        created.ClientId.Should().Be(clientId);
+        created.FinalPrice.Should().Be(finalPrice);
+
+        var completed = new SaleCompletedDomainEvent(saleId);
+        completed.SaleId.Should().Be(saleId);
+
+        var cancelled = new SaleCancelledDomainEvent(saleId, reason);
+        cancelled.SaleId.Should().Be(saleId);
+        cancelled.Reason.Should().Be(reason);
+    }
+}


### PR DESCRIPTION
## Summary
- add DomainTests project referencing Domain and SharedKernel
- test Car, Client and Sale constructors, error helpers and domain events using fake data

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689698420394832dab1a496150e6a1ae