### PR TITLE
Add integration tests for Web API endpoints

### DIFF
--- a/tests/WebApiTests/CarsEndpointsTests.cs
+++ b/tests/WebApiTests/CarsEndpointsTests.cs
@@ -1,0 +1,102 @@
+using Application.Cars.GetById;
+using Domain.Cars;
+using Domain.Cars.Atribbutes;
+using Infrastructure.Database;
+
+namespace WebApiTests;
+
+public class CarsEndpointsTests
+{
+    [Fact]
+    public async Task CreateCar_AddsCarToDatabase()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var marca = new Marca("Toyota") { Id = Guid.NewGuid() };
+        var modelo = new Modelo("Corolla", marca.Id) { Id = Guid.NewGuid(), Marca = marca };
+        context.AddRange(marca, modelo);
+        await context.SaveChangesAsync();
+
+        var client = factory.CreateClient();
+        var request = new
+        {
+            Marca = marca.Id.ToString(),
+            Modelo = modelo.Id.ToString(),
+            Color = (int)Color.White,
+            CarType = (int)TypeCar.Sedan,
+            CarStatus = (int)StatusCar.New,
+            ServiceCar = (int)statusServiceCar.Disponible,
+            CantidadPuertas = 4,
+            CantidadAsientos = 5,
+            Cilindrada = 2000,
+            Kilometraje = 10000,
+            Año = 2020,
+            Patente = "ABC123",
+            Descripcion = "Test",
+            Precio = 10000m
+        };
+
+        var response = await client.PostAsJsonAsync("/cars", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var id = await response.Content.ReadFromJsonAsync<Guid>();
+
+        context.Cars.Should().ContainSingle(c => c.Id == id);
+    }
+
+    [Fact]
+    public async Task CreateCar_ReturnsBadRequest_ForInvalidColor()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+        var request = new
+        {
+            Marca = Guid.NewGuid().ToString(),
+            Modelo = Guid.NewGuid().ToString(),
+            Color = 999,
+            CarType = (int)TypeCar.Sedan,
+            CarStatus = (int)StatusCar.New,
+            ServiceCar = (int)statusServiceCar.Disponible,
+            CantidadPuertas = 4,
+            CantidadAsientos = 5,
+            Cilindrada = 2000,
+            Kilometraje = 10000,
+            Año = 2020,
+            Patente = "ABC123",
+            Descripcion = "Test",
+            Precio = 10000m
+        };
+
+        var response = await client.PostAsJsonAsync("/cars", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetCarById_ReturnsCar_WhenExists()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var marca = new Marca("Ford") { Id = Guid.NewGuid() };
+        var modelo = new Modelo("Fiesta", marca.Id) { Id = Guid.NewGuid(), Marca = marca };
+        var car = new Car(marca, modelo, Color.Blue, TypeCar.Sedan, StatusCar.New, statusServiceCar.Disponible, 4,5,1600,5000,2019,"XYZ987","desc",15000m, DateTime.UtcNow);
+        context.AddRange(marca, modelo, car);
+        await context.SaveChangesAsync();
+
+        var client = factory.CreateClient();
+        var response = await client.GetAsync($"/cars/{car.Id}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CarGetByIdResponse>();
+        result!.Id.Should().Be(car.Id);
+        result.Marca.Should().Be("Ford");
+    }
+
+    [Fact]
+    public async Task GetCarById_ReturnsNotFound_WhenMissing()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+        var response = await client.GetAsync($"/cars/{Guid.NewGuid()}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/WebApiTests/ClientsEndpointsTests.cs
+++ b/tests/WebApiTests/ClientsEndpointsTests.cs
@@ -1,0 +1,78 @@
+using Application.Clients.GetAll;
+using Domain.Clients;
+using Infrastructure.Database;
+
+namespace WebApiTests;
+
+public class ClientsEndpointsTests
+{
+    [Fact]
+    public async Task CreateClient_PersistsClient()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+        var request = new
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john@example.com",
+            Phone = "123",
+            Address = "Street 1",
+            DNI = "111"
+        };
+
+        var response = await client.PostAsJsonAsync("/clients", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var id = await response.Content.ReadFromJsonAsync<Guid>();
+
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        context.Clients.Should().ContainSingle(c => c.Id == id);
+    }
+
+    [Fact]
+    public async Task CreateClient_ReturnsBadRequest_WhenInvalid()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+        var request = new
+        {
+            FirstName = string.Empty,
+            LastName = "Doe",
+            Email = "john@example.com",
+            Phone = "123",
+            Address = "Street",
+            DNI = "111"
+        };
+
+        var response = await client.PostAsJsonAsync("/clients", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetClientById_ReturnsClient_WhenExists()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var entity = new Client("Jane", "Smith", "222", "jane@example.com", "456", "Road");
+        context.Clients.Add(entity);
+        await context.SaveChangesAsync();
+
+        var httpClient = factory.CreateClient();
+        var response = await httpClient.GetAsync($"/clients/{entity.Id}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ClientResponse>();
+        result!.Id.Should().Be(entity.Id);
+        result.FirstName.Should().Be("Jane");
+    }
+
+    [Fact]
+    public async Task GetClientById_ReturnsNotFound_WhenMissing()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var httpClient = factory.CreateClient();
+        var response = await httpClient.GetAsync($"/clients/{Guid.NewGuid()}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/WebApiTests/CustomWebApplicationFactory.cs
+++ b/tests/WebApiTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,37 @@
+using Application.Abstractions.Data;
+using Infrastructure.Database;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Web.Api;
+
+namespace WebApiTests;
+
+public sealed class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    private readonly string _dbName = Guid.NewGuid().ToString();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll(typeof(DbContextOptions<ApplicationDbContext>));
+            services.RemoveAll(typeof(ApplicationDbContext));
+            services.RemoveAll(typeof(IApplicationDbContext));
+
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseInMemoryDatabase(_dbName));
+
+            services.AddScoped<IApplicationDbContext>(sp => sp.GetRequiredService<ApplicationDbContext>());
+
+            var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.Database.EnsureCreated();
+        });
+    }
+}

--- a/tests/WebApiTests/GlobalUsings.cs
+++ b/tests/WebApiTests/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Xunit;
+global using FluentAssertions;
+global using System.Net;
+global using System.Net.Http.Json;

--- a/tests/WebApiTests/SalesEndpointsTests.cs
+++ b/tests/WebApiTests/SalesEndpointsTests.cs
@@ -1,0 +1,84 @@
+using Application.Sales.Get;
+using Domain.Cars;
+using Domain.Cars.Atribbutes;
+using Domain.Clients;
+using Domain.Financial.Attributes;
+using Infrastructure.Database;
+
+namespace WebApiTests;
+
+public class SalesEndpointsTests
+{
+    [Fact]
+    public async Task CreateSale_AddsSaleAndUpdatesCar()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var marca = new Marca("VW") { Id = Guid.NewGuid() };
+        var modelo = new Modelo("Golf", marca.Id) { Id = Guid.NewGuid(), Marca = marca };
+        var car = new Car(marca, modelo, Color.Gray, TypeCar.Sedan, StatusCar.New, statusServiceCar.Disponible, 4,5,1600,0,2021,"AAA111","desc",20000m, DateTime.UtcNow);
+        var clientEntity = new Client("Alice", "Green", "333", "alice@example.com", "789", "Ave");
+        context.AddRange(marca, modelo, car, clientEntity);
+        await context.SaveChangesAsync();
+
+        var http = factory.CreateClient();
+        var request = new
+        {
+            CarId = car.Id,
+            ClientId = clientEntity.Id,
+            FinalPrice = 18000m,
+            PaymentMethod = PaymentMethod.Cash,
+            Status = "Pending",
+            ContractNumber = "C123",
+            Comments = "none"
+        };
+        var response = await http.PostAsJsonAsync("/sales", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var saleId = await response.Content.ReadFromJsonAsync<Guid>();
+
+        context.Sales.Should().ContainSingle(s => s.Id == saleId);
+        context.Cars.Single(c => c.Id == car.Id).ServiceCar.Should().Be(statusServiceCar.Vendido);
+
+        var get = await http.GetAsync($"/sales/{saleId}");
+        get.StatusCode.Should().Be(HttpStatusCode.OK);
+        var saleResponse = await get.Content.ReadFromJsonAsync<SaleResponse>();
+        saleResponse!.Id.Should().Be(saleId);
+        saleResponse.CarBrand.Should().Be("VW");
+    }
+
+    [Fact]
+    public async Task CreateSale_ReturnsBadRequest_WhenCarMissing()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var clientEntity = new Client("Bob", "Brown", "444", "bob@example.com", "555", "Street");
+        context.Clients.Add(clientEntity);
+        await context.SaveChangesAsync();
+
+        var http = factory.CreateClient();
+        var request = new
+        {
+            CarId = Guid.NewGuid(),
+            ClientId = clientEntity.Id,
+            FinalPrice = 1000m,
+            PaymentMethod = PaymentMethod.Cash,
+            Status = "Pending",
+            ContractNumber = "C1",
+            Comments = "none"
+        };
+        var response = await http.PostAsJsonAsync("/sales", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetSaleById_ReturnsNotFound_WhenMissing()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var http = factory.CreateClient();
+        var response = await http.GetAsync($"/sales/{Guid.NewGuid()}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/WebApiTests/UsersEndpointsTests.cs
+++ b/tests/WebApiTests/UsersEndpointsTests.cs
@@ -1,0 +1,66 @@
+using Application.Users.GetById;
+using Infrastructure.Database;
+using System.Net.Http.Headers;
+
+namespace WebApiTests;
+
+public class UsersEndpointsTests
+{
+    [Fact]
+    public async Task RegisterUser_CreatesUser()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+        var request = new { Email = "user@example.com", FirstName = "User", LastName = "Test", Password = "Password1!" };
+        var response = await client.PostAsJsonAsync("/users/register", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var id = await response.Content.ReadFromJsonAsync<Guid>();
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        context.Users.Should().ContainSingle(u => u.Id == id);
+    }
+
+    [Fact]
+    public async Task RegisterUser_ReturnsConflict_WhenEmailExists()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+        var request = new { Email = "dup@example.com", FirstName = "User", LastName = "Test", Password = "Password1!" };
+        await client.PostAsJsonAsync("/users/register", request);
+        var response = await client.PostAsJsonAsync("/users/register", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task GetUserById_ReturnsUnauthorized_WithoutToken()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+        var register = new { Email = "noauth@example.com", FirstName = "No", LastName = "Auth", Password = "Password1!" };
+        var regResponse = await client.PostAsJsonAsync("/users/register", register);
+        var userId = await regResponse.Content.ReadFromJsonAsync<Guid>();
+        var response = await client.GetAsync($"/users/{userId}");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetUserById_ReturnsUser_WhenAuthorized()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+        var register = new { Email = "auth@example.com", FirstName = "Auth", LastName = "User", Password = "Password1!" };
+        var regResponse = await client.PostAsJsonAsync("/users/register", register);
+        var userId = await regResponse.Content.ReadFromJsonAsync<Guid>();
+
+        var login = new { Email = "auth@example.com", Password = "Password1!" };
+        var loginResponse = await client.PostAsJsonAsync("/users/login", login);
+        var token = await loginResponse.Content.ReadFromJsonAsync<string>();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync($"/users/{userId}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<UserResponse>();
+        result!.Id.Should().Be(userId);
+        result.Email.Should().Be("auth@example.com");
+    }
+}

--- a/tests/WebApiTests/WebApiTests.csproj
+++ b/tests/WebApiTests/WebApiTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Web.Api\Web.Api.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add WebApiTests project with WebApplicationFactory using in-memory database
- test cars, clients, sales and users endpoints including success and error scenarios
- cover authorization checks and database side effects

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6896983bf220832dac766536776a4262