### PR TITLE
Add application handler unit tests

### DIFF
--- a/CleanArchitecture.sln
+++ b/CleanArchitecture.sln
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1EB88D85
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArchitectureTests", "tests\ArchitectureTests\ArchitectureTests.csproj", "{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplicationTests", "tests\ApplicationTests\ApplicationTests.csproj", "{B005223D-0889-4B5B-B55C-CBDED45FBA5F}"
+EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{34BB3069-D5D0-4046-ACAD-A2025ED7678F}"
 EndProject
 Global
@@ -54,16 +56,20 @@ Global
 		{86506D03-3746-41E7-A645-97D3633981DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{86506D03-3746-41E7-A645-97D3633981DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{86506D03-3746-41E7-A645-97D3633981DB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B005223D-0889-4B5B-B55C-CBDED45FBA5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B005223D-0889-4B5B-B55C-CBDED45FBA5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B005223D-0889-4B5B-B55C-CBDED45FBA5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B005223D-0889-4B5B-B55C-CBDED45FBA5F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {34BB3069-D5D0-4046-ACAD-A2025ED7678F}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
@@ -72,9 +78,10 @@ Global
 		{0F576D4A-156D-4626-A4D5-83DD0F6FAFE7} = {64A28C1B-09AF-426E-8721-D002BE554B48}
 		{C699FD09-4D82-4C4B-8744-4FD3B0D60EFC} = {64A28C1B-09AF-426E-8721-D002BE554B48}
 		{86506D03-3746-41E7-A645-97D3633981DB} = {64A28C1B-09AF-426E-8721-D002BE554B48}
-		{8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA} = {1EB88D85-BE1E-46DE-99A2-2F02363060AF}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {B948A3CC-9872-4612-ABD2-BB3D49671542}
-	EndGlobalSection
+                {8D8E2A8A-D3FE-4230-BEF7-C427D6BD87DA} = {1EB88D85-BE1E-46DE-99A2-2F02363060AF}
+                {B005223D-0889-4B5B-B55C-CBDED45FBA5F} = {1EB88D85-BE1E-46DE-99A2-2F02363060AF}
+        EndGlobalSection
+        GlobalSection(ExtensibilityGlobals) = postSolution
+                SolutionGuid = {B948A3CC-9872-4612-ABD2-BB3D49671542}
+        EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
     <PackageVersion Include="Serilog" Version="4.2.0" />
     <!-- Infrastructure -->

--- a/tests/ApplicationTests/ApplicationTests.csproj
+++ b/tests/ApplicationTests/ApplicationTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>Application.UnitTests</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Application\Application.csproj" />
+    <ProjectReference Include="..\..\src\Domain\Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ApplicationTests/Cars/CreateCarCommandHandlerTests.cs
+++ b/tests/ApplicationTests/Cars/CreateCarCommandHandlerTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using Application.Cars.Create;
+using Domain.Cars;
+using Domain.Cars.Atribbutes;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.UnitTests.Cars;
+
+public class CreateCarCommandHandlerTests
+{
+    private static TestApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<TestApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new TestApplicationDbContext(options);
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateCar_WhenAttributesAreValid()
+    {
+        using var context = CreateContext();
+        var dateProvider = new FakeDateTimeProvider { UtcNow = new DateTime(2024, 1, 1) };
+        var marca = new Marca("Toyota");
+        var modelo = new Modelo("Corolla", marca.Id);
+        context.Marca.Add(marca);
+        context.Modelo.Add(modelo);
+        await context.SaveChangesAsync();
+
+        var handler = new CreateCarCommandHandler(context, dateProvider);
+
+        var command = new CreateCarCommand
+        {
+            Marca = marca.Id,
+            Modelo = modelo.Id,
+            Color = Color.Blue,
+            CarType = TypeCar.Sedan,
+            CarStatus = StatusCar.New,
+            ServiceCar = statusServiceCar.Disponible,
+            CantidadPuertas = 4,
+            CantidadAsientos = 5,
+            Cilindrada = 2000,
+            Kilometraje = 0,
+            Año = 2024,
+            Patente = "ABC123",
+            Descripcion = "New car",
+            Price = 20000m
+        };
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        context.Cars.Should().ContainSingle(c => c.Id == result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnFailure_When_Marca_NotFound()
+    {
+        using var context = CreateContext();
+        var dateProvider = new FakeDateTimeProvider();
+        var handler = new CreateCarCommandHandler(context, dateProvider);
+
+        var command = new CreateCarCommand
+        {
+            Marca = Guid.NewGuid(),
+            Modelo = Guid.NewGuid(),
+            Color = Color.Black,
+            CarType = TypeCar.Sedan,
+            CarStatus = StatusCar.New,
+            ServiceCar = statusServiceCar.Disponible,
+            CantidadPuertas = 4,
+            CantidadAsientos = 5,
+            Cilindrada = 2000,
+            Kilometraje = 0,
+            Año = 2024,
+            Patente = "DEF456",
+            Descripcion = "Invalid car",
+            Price = 15000m
+        };
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(CarErrors.AtributesInvalid());
+        context.Cars.Should().BeEmpty();
+    }
+}

--- a/tests/ApplicationTests/Clients/UpdateClientCommandHandlerTests.cs
+++ b/tests/ApplicationTests/Clients/UpdateClientCommandHandlerTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Clients.Update;
+using Domain.Clients;
+using Domain.Clients.Attributes;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.UnitTests.Clients;
+
+public class UpdateClientCommandHandlerTests
+{
+    private static TestApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<TestApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new TestApplicationDbContext(options);
+    }
+
+    [Fact]
+    public async Task Handle_Should_UpdateClient_WhenFound()
+    {
+        using var context = CreateContext();
+        var dateProvider = new FakeDateTimeProvider { UtcNow = new DateTime(2024, 1, 1) };
+        var client = new Client("John", "Doe", "123", "john@test.com", "555", "Street 1");
+        context.Clients.Add(client);
+        await context.SaveChangesAsync();
+
+        var handler = new UpdateClientCommandHandler(context, dateProvider);
+        var command = new UpdateClientCommand(client.Id, "Jane", "Smith", "456", "jane@test.com", "999", "Street 2", ClientStatus.Inactive);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var updated = await context.Clients.FindAsync(client.Id);
+        updated!.FirstName.Should().Be("Jane");
+        updated.UpdateAt.Should().Be(dateProvider.UtcNow);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnFailure_WhenClientNotFound()
+    {
+        using var context = CreateContext();
+        var dateProvider = new FakeDateTimeProvider();
+        var handler = new UpdateClientCommandHandler(context, dateProvider);
+        var id = Guid.NewGuid();
+        var command = new UpdateClientCommand(id, "Jane", "Doe", "123", "jane@test.com", "000", "Address", ClientStatus.Active);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ClientErrors.NotFound(id));
+    }
+}

--- a/tests/ApplicationTests/FakeDateTimeProvider.cs
+++ b/tests/ApplicationTests/FakeDateTimeProvider.cs
@@ -1,0 +1,9 @@
+using System;
+using SharedKernel;
+
+namespace Application.UnitTests;
+
+internal sealed class FakeDateTimeProvider : IDateTimeProvider
+{
+    public DateTime UtcNow { get; set; } = new DateTime(2024, 1, 1);
+}

--- a/tests/ApplicationTests/GlobalUsings.cs
+++ b/tests/ApplicationTests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using FluentAssertions;

--- a/tests/ApplicationTests/Sales/CreateSaleCommandHandlerTests.cs
+++ b/tests/ApplicationTests/Sales/CreateSaleCommandHandlerTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using Application.Sales.Create;
+using Domain.Cars;
+using Domain.Cars.Atribbutes;
+using Domain.Clients;
+using Domain.Financial.Attributes;
+using Domain.Sales;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.UnitTests.Sales;
+
+public class CreateSaleCommandHandlerTests
+{
+    private static TestApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<TestApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new TestApplicationDbContext(options);
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateSale_WhenDataIsValid()
+    {
+        using var context = CreateContext();
+        var marca = new Marca("Ford");
+        var modelo = new Modelo("Fiesta", marca.Id);
+        var car = new Car(marca, modelo, Color.Red, TypeCar.Sedan, StatusCar.New, statusServiceCar.Disponible, 4, 5, 1600, 1000, 2020, "XYZ789", "desc", 10000m, DateTime.UtcNow);
+        var client = new Client("Alice", "Johnson", "789", "alice@test.com", "111", "Addr1");
+        context.Marca.Add(marca);
+        context.Modelo.Add(modelo);
+        context.Cars.Add(car);
+        context.Clients.Add(client);
+        await context.SaveChangesAsync();
+
+        var handler = new CreateSaleCommandHandler(context);
+        var command = new CreateSaleCommand(car.Id, client.Id, 9000m, PaymentMethod.Cash, "CN123", "ok");
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        context.Sales.Should().ContainSingle(s => s.Id == result.Value);
+        (await context.Cars.FindAsync(car.Id))!.ServiceCar.Should().Be(statusServiceCar.Vendido);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnFailure_When_Car_NotFound()
+    {
+        using var context = CreateContext();
+        var client = new Client("Bob", "Brown", "123", "bob@test.com", "111", "Addr");
+        context.Clients.Add(client);
+        await context.SaveChangesAsync();
+
+        var handler = new CreateSaleCommandHandler(context);
+        var carId = Guid.NewGuid();
+        var command = new CreateSaleCommand(carId, client.Id, 1000m, PaymentMethod.Cash, "C", "comment");
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(SalesErrors.NotFound(carId));
+        context.Sales.Should().BeEmpty();
+    }
+}

--- a/tests/ApplicationTests/TestApplicationDbContext.cs
+++ b/tests/ApplicationTests/TestApplicationDbContext.cs
@@ -1,0 +1,30 @@
+using Application.Abstractions.Data;
+using Domain.Cars;
+using Domain.Cars.Atribbutes;
+using Domain.Clients;
+using Domain.Financial;
+using Domain.Financial.Attributes;
+using Domain.Quotes;
+using Domain.Sales;
+using Domain.Users;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.UnitTests;
+
+internal sealed class TestApplicationDbContext : DbContext, IApplicationDbContext
+{
+    public TestApplicationDbContext(DbContextOptions<TestApplicationDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Car> Cars => Set<Car>();
+    public DbSet<Client> Clients => Set<Client>();
+    public DbSet<Quote> Quotes => Set<Quote>();
+    public DbSet<Marca> Marca => Set<Marca>();
+    public DbSet<Modelo> Modelo => Set<Modelo>();
+    public DbSet<Sale> Sales => Set<Sale>();
+    public DbSet<FinancialTransaction> Transactions => Set<FinancialTransaction>();
+    public DbSet<TransactionCategory> TransactionCategories => Set<TransactionCategory>();
+    public DbSet<User> Users => Set<User>();
+    public DbSet<CarImage> CarImages => Set<CarImage>();
+}


### PR DESCRIPTION
## Summary
- add ApplicationTests project with in-memory DbContext and fake date provider
- cover CreateCarCommandHandler, UpdateClientCommandHandler and CreateSaleCommandHandler success and failure flows
- configure EF Core InMemory package and wire up project in solution

## Testing
- `dotnet test tests/ApplicationTests/ApplicationTests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689698402568832d8e614bac2bedd2fd