### PR TITLE
Improve storage resiliency and API experience

### DIFF
--- a/src/Application/Abstractions/Storage/IBlobStorageService.cs
+++ b/src/Application/Abstractions/Storage/IBlobStorageService.cs
@@ -10,5 +10,5 @@ public interface IBlobStorageService
     Task<byte[]> DownloadAsync(string containerName, string blobName, CancellationToken cancellationToken = default);
     Task DeleteAsync(string containerName, string blobName, CancellationToken cancellationToken = default);
     Task<bool> ExistsAsync(string containerName, string blobName, CancellationToken cancellationToken = default);
-    Uri GenerateSasUri(Azure.Storage.Blobs.BlobClient blobClient);
-} 
+    Task<string> GenerateAccessUrlAsync(string containerName, string blobName, CancellationToken cancellationToken = default);
+}

--- a/src/Domain/Cars/Car.cs
+++ b/src/Domain/Cars/Car.cs
@@ -6,10 +6,10 @@ namespace Domain.Cars;
 
 public sealed class Car : Entity
 {
-    public Guid MarcaId { get; set; }
-    public Marca Marca { get; set; }
-    public Guid ModeloId { get; set; }
-    public Modelo Modelo { get; set; }
+public Guid MarcaId { get; set; }
+public Marca Marca { get; set; } = null!;
+public Guid ModeloId { get; set; }
+public Modelo Modelo { get; set; } = null!;
     public Color Color { get; set; }
     public TypeCar CarType { get; set; }
     public StatusCar CarStatus { get; set; }
@@ -20,8 +20,8 @@ public sealed class Car : Entity
     public int Cilindrada { get; set; }
     public int Kilometraje { get; set; }
     public int Año { get; set; }
-    public string Patente { get; set; }
-    public string Descripcion { get; set; }
+public string Patente { get; set; } = string.Empty;
+public string Descripcion { get; set; } = string.Empty;
     public ICollection<CarImage> Images { get; set; } = new List<CarImage>();
 
     public DateTime CreatedAt { get; set; }

--- a/src/Domain/Cars/CarImages.cs
+++ b/src/Domain/Cars/CarImages.cs
@@ -5,11 +5,11 @@ namespace Domain.Cars;
 public class CarImage:Entity
 {
 
-    public Guid CarId { get; set; }
-    public string ImageUrl { get; set; } // URL de la imagen en Azure Blob Storage
-    public bool IsPrimary { get; set; } // Indica si es la imagen principal
-    public int Order { get; set; }     // Orden de la imagen
-    public Car Car { get; set; }
+public Guid CarId { get; set; }
+public string ImageUrl { get; set; } = string.Empty; // URL de la imagen en Azure Blob Storage
+public bool IsPrimary { get; set; } // Indica si es la imagen principal
+public int Order { get; set; }     // Orden de la imagen
+public Car Car { get; set; } = null!;
 
     public CarImage()
     {

--- a/src/Infrastructure/Database/ApplicationDbContext.cs
+++ b/src/Infrastructure/Database/ApplicationDbContext.cs
@@ -19,21 +19,21 @@ public sealed class ApplicationDbContext : DbContext, IApplicationDbContext
 {
     private readonly IPublisher publisher;
 
-    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, IPublisher _publisher) : base(options)
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, IPublisher publisher) : base(options)
     {
-        publisher = _publisher;
+        this.publisher = publisher;
     }
 
-    public DbSet<Car> Cars { get; set; }
-    public DbSet<Client> Clients { get; set; }
-    public DbSet<Quote> Quotes { get; set; }
-    public DbSet<Sale> Sales { get; set; }
-    public DbSet<Modelo> Modelo { get; set; }
-    public DbSet<Marca> Marca { get; set; }
-    public DbSet<FinancialTransaction> Transactions { get; set; }
-    public DbSet<TransactionCategory> TransactionCategories { get; set; }
-    public DbSet<User> Users { get; set; }
-    public DbSet<CarImage> CarImages { get; set; }
+    public DbSet<Car> Cars => Set<Car>();
+    public DbSet<Client> Clients => Set<Client>();
+    public DbSet<Quote> Quotes => Set<Quote>();
+    public DbSet<Sale> Sales => Set<Sale>();
+    public DbSet<Modelo> Modelo => Set<Modelo>();
+    public DbSet<Marca> Marca => Set<Marca>();
+    public DbSet<FinancialTransaction> Transactions => Set<FinancialTransaction>();
+    public DbSet<TransactionCategory> TransactionCategories => Set<TransactionCategory>();
+    public DbSet<User> Users => Set<User>();
+    public DbSet<CarImage> CarImages => Set<CarImage>();
 
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/Infrastructure/Storage/AzureBlobStorageService.cs
+++ b/src/Infrastructure/Storage/AzureBlobStorageService.cs
@@ -4,7 +4,9 @@ using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -14,15 +16,18 @@ namespace Infrastructure.Storage;
 
 public class AzureBlobStorageService : IBlobStorageService
 {
-    private readonly BlobServiceClient _blobServiceClient;
-    private readonly string _accountName;
-    private readonly string _accountKey;
+    private readonly BlobServiceClient blobServiceClient;
+    private readonly ILogger<AzureBlobStorageService> logger;
+    private readonly string accountName;
+    private readonly string accountKey;
 
-    public AzureBlobStorageService(IConfiguration configuration)
+    public AzureBlobStorageService(IConfiguration configuration, ILogger<AzureBlobStorageService> logger)
     {
-        string connectionString = configuration["AzureBlobStorage:ConnectionString"] 
+        this.logger = logger;
+
+        string connectionString = configuration["AzureBlobStorage:ConnectionString"]
             ?? throw new ArgumentNullException(nameof(configuration), "La cadena de conexión de Azure Blob Storage no está configurada");
-            
+
         if (string.IsNullOrWhiteSpace(connectionString))
         {
             throw new ArgumentException("La cadena de conexión de Azure Blob Storage está vacía");
@@ -30,28 +35,26 @@ public class AzureBlobStorageService : IBlobStorageService
 
         try
         {
-            _blobServiceClient = new BlobServiceClient(connectionString);
-            
-            // Extraer el nombre de la cuenta y la clave de la cadena de conexión
-            var connectionStringParts = connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)
-                .ToDictionary(
-                    part => part.Split('=', 2)[0].Trim(),
-                    part => part.Split('=', 2)[1].Trim(),
-                    StringComparer.OrdinalIgnoreCase
-                );
-            
-            if (!connectionStringParts.TryGetValue("AccountName", out string accountName))
+            blobServiceClient = new BlobServiceClient(connectionString);
+
+            Dictionary<string, string> connectionStringParts = connectionString
+                .Split(';', StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Split('=', 2))
+                .Where(parts => parts.Length == 2)
+                .ToDictionary(parts => parts[0].Trim(), parts => parts[1].Trim(), StringComparer.OrdinalIgnoreCase);
+
+            if (!connectionStringParts.TryGetValue("AccountName", out string? parsedAccountName))
             {
                 throw new ArgumentException("No se encontró AccountName en la cadena de conexión");
             }
-            
-            if (!connectionStringParts.TryGetValue("AccountKey", out string accountKey))
+
+            if (!connectionStringParts.TryGetValue("AccountKey", out string? parsedAccountKey))
             {
                 throw new ArgumentException("No se encontró AccountKey en la cadena de conexión");
             }
-            
-            _accountName = accountName;
-            _accountKey = accountKey;
+
+            accountName = parsedAccountName;
+            accountKey = parsedAccountKey;
         }
         catch (Exception ex)
         {
@@ -61,7 +64,7 @@ public class AzureBlobStorageService : IBlobStorageService
 
     public async Task<string> UploadAsync(string containerName, string blobName, byte[] data, CancellationToken cancellationToken = default)
     {
-        BlobContainerClient containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+        BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(containerName);
         await containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
 
         BlobClient blobClient = containerClient.GetBlobClient(blobName);
@@ -69,13 +72,12 @@ public class AzureBlobStorageService : IBlobStorageService
         using var stream = new MemoryStream(data);
         await blobClient.UploadAsync(stream, new BlobUploadOptions(), cancellationToken);
 
-        // Generar URL con token SAS
-        return GenerateSasUri(blobClient).ToString();
+        return CreateSasUri(blobClient).ToString();
     }
 
     public async Task<byte[]> DownloadAsync(string containerName, string blobName, CancellationToken cancellationToken = default)
     {
-        BlobContainerClient containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+        BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(containerName);
         BlobClient blobClient = containerClient.GetBlobClient(blobName);
 
         using var memoryStream = new MemoryStream();
@@ -85,7 +87,7 @@ public class AzureBlobStorageService : IBlobStorageService
 
     public async Task DeleteAsync(string containerName, string blobName, CancellationToken cancellationToken = default)
     {
-        BlobContainerClient containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+        BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(containerName);
         BlobClient blobClient = containerClient.GetBlobClient(blobName);
 
         await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
@@ -93,61 +95,50 @@ public class AzureBlobStorageService : IBlobStorageService
 
     public async Task<bool> ExistsAsync(string containerName, string blobName, CancellationToken cancellationToken = default)
     {
-        BlobContainerClient containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+        BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(containerName);
         BlobClient blobClient = containerClient.GetBlobClient(blobName);
 
         return await blobClient.ExistsAsync(cancellationToken);
     }
 
-    public Uri GenerateSasUri(BlobClient blobClient)
+    public Task<string> GenerateAccessUrlAsync(string containerName, string blobName, CancellationToken cancellationToken = default)
+    {
+        BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+        BlobClient blobClient = containerClient.GetBlobClient(blobName);
+
+        return Task.FromResult(CreateSasUri(blobClient).ToString());
+    }
+
+    private Uri CreateSasUri(BlobClient blobClient)
     {
         try
         {
-            Console.WriteLine($"Generando SAS para blob: {blobClient.Uri}, Container: {blobClient.BlobContainerName}, Blob: {blobClient.Name}");
-            Console.WriteLine($"AccountName: {_accountName}, AccountKey length: {_accountKey?.Length ?? 0}");
-            
-            // Crear un token SAS que expire en 1 año
             var sasBuilder = new BlobSasBuilder
             {
                 BlobContainerName = blobClient.BlobContainerName,
                 BlobName = blobClient.Name,
                 Resource = "b",
                 ExpiresOn = DateTimeOffset.UtcNow.AddYears(1),
-                StartsOn = DateTimeOffset.UtcNow.AddMinutes(-5) // Permitir un pequeño margen de tiempo
+                StartsOn = DateTimeOffset.UtcNow.AddMinutes(-5)
             };
 
-            // Establecer permisos de lectura
             sasBuilder.SetPermissions(BlobSasPermissions.Read);
-            
-            if (string.IsNullOrEmpty(_accountName) || string.IsNullOrEmpty(_accountKey))
+
+            if (string.IsNullOrEmpty(accountName) || string.IsNullOrEmpty(accountKey))
             {
-                throw new InvalidOperationException($"Credenciales de Azure inválidas. AccountName: {_accountName}, AccountKey: {(_accountKey != null ? "presente" : "ausente")}");
+                throw new InvalidOperationException("Credenciales de Azure inválidas");
             }
 
-            // Crear las credenciales de almacenamiento de forma más directa
-            var storageSharedKeyCredential = new StorageSharedKeyCredential(_accountName, _accountKey);
-
-            // Generar el token SAS con opciones específicas
+            var storageSharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey);
             var sasToken = sasBuilder.ToSasQueryParameters(storageSharedKeyCredential).ToString();
-
-            // Construir la URI con el token SAS de forma más segura
             var uriBuilder = new UriBuilder(blobClient.Uri) { Query = sasToken };
-            Console.WriteLine($"SAS generado correctamente: {uriBuilder.Uri}");
+
             return uriBuilder.Uri;
         }
         catch (Exception ex)
         {
-            // Registrar el error específico para diagnóstico
-            Console.WriteLine($"Error detallado al generar SAS en funcion: {ex}");
-            Console.WriteLine($"StackTrace: {ex.StackTrace}");
-            
-            if (ex.InnerException != null)
-            {
-                Console.WriteLine($"InnerException: {ex.InnerException.Message}");
-                Console.WriteLine($"InnerException StackTrace: {ex.InnerException.StackTrace}");
-            }
-            
-            throw new InvalidOperationException($"Error al generar URL con SAS en funcion: {ex.Message}", ex);
+            logger.LogError(ex, "Error al generar URL con SAS para el blob {BlobUri}", blobClient.Uri);
+            throw new InvalidOperationException($"Error al generar URL con SAS: {ex.Message}", ex);
         }
     }
 }

--- a/src/Infrastructure/Storage/LocalFileStorageService.cs
+++ b/src/Infrastructure/Storage/LocalFileStorageService.cs
@@ -73,10 +73,16 @@ public class LocalFileStorageService : IBlobStorageService
         return Task.FromResult(exists);
     }
 
-    public Uri GenerateSasUri(Azure.Storage.Blobs.BlobClient blobClient)
+    public Task<string> GenerateAccessUrlAsync(string containerName, string blobName, CancellationToken cancellationToken = default)
     {
-        // Para almacenamiento local, simplemente devolvemos la URI original
-        // ya que no necesitamos tokens SAS para acceso local
-        return blobClient.Uri;
+        string filePath = Path.Combine(_basePath, containerName, blobName);
+
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"El archivo {blobName} no se encontró en el contenedor {containerName}");
+        }
+
+        string sanitizedBaseUrl = _baseUrl.TrimEnd('/');
+        return Task.FromResult($"{sanitizedBaseUrl}/{containerName}/{blobName}");
     }
-} 
+}

--- a/src/Web.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Web.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -1,11 +1,20 @@
-﻿namespace Web.Api.Extensions;
+using Swashbuckle.AspNetCore.SwaggerUI;
+
+namespace Web.Api.Extensions;
 
 public static class ApplicationBuilderExtensions
 {
     public static IApplicationBuilder UseSwaggerWithUi(this WebApplication app)
     {
         app.UseSwagger();
-        app.UseSwaggerUI();
+        app.UseSwaggerUI(options =>
+        {
+            options.DocumentTitle = "Car Store API";
+            options.DisplayRequestDuration();
+            options.EnableTryItOutByDefault();
+            options.DocExpansion(DocExpansion.None);
+            options.InjectStylesheet("/swagger-ui/custom.css");
+        });
 
         return app;
     }

--- a/src/Web.Api/appsettings.Development.json
+++ b/src/Web.Api/appsettings.Development.json
@@ -6,6 +6,16 @@
     "ConnectionString": "DefaultEndpointsProtocol=https;AccountName=conscard;AccountKey=SGa+k7UuLxZ0/FEwsr8Q0HIzKZk+GkHqcsdCyb5RCCaS3SRn7yaE16pjw7/MFeajcPt6QulDBGw0+AStFR/Xlw==;EndpointSuffix=core.windows.net",
     "ContainerName": "concardimage"
   },
+  "LocalStorage": {
+    "BasePath": "uploads",
+    "BaseUrl": "/uploads"
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000"
+    ],
+    "AllowCredentials": true
+  },
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console",

--- a/src/Web.Api/appsettings.json
+++ b/src/Web.Api/appsettings.json
@@ -1,41 +1,46 @@
 {
   "AllowedHosts": "*",
-    "ConnectionStrings": {
-      "Database": "Host=localhost;Port=5432;Database=cleanarchitecture;Username=postgres;Password=postgres;"
+  "ConnectionStrings": {
+    "Database": "Host=localhost;Port=5432;Database=cleanarchitecture;Username=postgres;Password=postgres;"
+  },
+  "AzureBlobStorage": {
+    "ConnectionString": "",
+    "ContainerName": ""
+  },
+  "LocalStorage": {
+    "BasePath": "uploads",
+    "BaseUrl": "/uploads"
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000"
+    ],
+    "AllowCredentials": true
+  },
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.Seq"
+    ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Information"
+      }
     },
-    "AzureBlobStorage": {
-      "ConnectionString": "",
-      "ContainerName": ""
-    },
-    "LocalStorage": {
-      "BasePath": "uploads",
-      "BaseUrl": "/uploads"
-    },
-    "Serilog": {
-      "Using": [
-        "Serilog.Sinks.Console",
-        "Serilog.Sinks.Seq"
-      ],
-      "MinimumLevel": {
-        "Default": "Information",
-        "Override": {
-          "Microsoft": "Information"
-        }
-      },
-      "WriteTo": [
-        { "Name": "Console" },
-        {
-          "Name": "Seq",
-          "Args": { "ServerUrl": "http://seq:5341" }
-        }
-      ],
-      "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
-    },
-    "Jwt": {
-      "Secret": "super-duper-secret-value-that-should-be-in-user-secrets",
-      "Issuer": "clean-architecture",
-      "Audience": "developers",
-      "ExpirationInMinutes": 60
-    }
+    "WriteTo": [
+      { "Name": "Console" },
+      {
+        "Name": "Seq",
+        "Args": { "ServerUrl": "http://seq:5341" }
+      }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
+  },
+  "Jwt": {
+    "Secret": "super-duper-secret-value-that-should-be-in-user-secrets",
+    "Issuer": "clean-architecture",
+    "Audience": "developers",
+    "ExpirationInMinutes": 60
   }
-  
+}

--- a/src/Web.Api/wwwroot/swagger-ui/custom.css
+++ b/src/Web.Api/wwwroot/swagger-ui/custom.css
@@ -1,0 +1,102 @@
+:root {
+  --swagger-primary: #0f172a;
+  --swagger-secondary: #1d4ed8;
+  --swagger-accent: #f97316;
+  --swagger-bg: #f5f5f4;
+}
+
+body.swagger-ui {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  min-height: 100vh;
+}
+
+.swagger-ui .topbar {
+  background-color: var(--swagger-primary);
+  padding: 1rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.2);
+}
+
+.swagger-ui .topbar-wrapper .link span {
+  color: #fff;
+  font-weight: 600;
+}
+
+.swagger-ui .scheme-container,
+.swagger-ui .information-container,
+.swagger-ui .opblock-tag-section {
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.swagger-ui .opblock {
+  border-radius: 1rem;
+  margin-bottom: 1.5rem;
+  border: none;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+.swagger-ui .opblock-summary-method {
+  border-radius: 999px;
+  padding: 0.3rem 1rem;
+  font-weight: 600;
+}
+
+.swagger-ui .btn.execute.opblock-control__btn {
+  background: linear-gradient(120deg, var(--swagger-secondary), var(--swagger-accent));
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.swagger-ui .btn.execute.opblock-control__btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(249, 115, 22, 0.35);
+}
+
+.swagger-ui .opblock-tag {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--swagger-primary);
+}
+
+.swagger-ui section.models.is-open h4,
+.swagger-ui section.models h4 {
+  font-weight: 600;
+  color: var(--swagger-secondary);
+}
+
+.swagger-ui .model-box {
+  border-radius: 0.75rem;
+  border-color: rgba(15, 23, 42, 0.12);
+}
+
+@media (max-width: 1024px) {
+  .swagger-ui .opblock-summary {
+    flex-wrap: wrap;
+  }
+
+  .swagger-ui .opblock-section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .swagger-ui .topbar {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .swagger-ui .opblock-summary-method,
+  .swagger-ui .opblock-summary-path,
+  .swagger-ui .opblock-summary-description {
+    width: 100%;
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- harden the blob storage abstraction and endpoints so SAS urls are regenerated centrally and local storage no longer depends on Azure types
- add flexible CORS configuration, reorder the request pipeline, and polish Swagger UI with a responsive custom theme
- tighten the domain model and DbContext nullability definitions while keeping configuration files self-descriptive

## Testing
- Not run (dotnet CLI unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3c7b79ec832dace2937d8ecb5d85)