### PR TITLE
fix(infra): drop redundant HostName unique index

### DIFF
--- a/src/Infrastructure/Database/Configurations/DealerSettingsConfiguration.cs
+++ b/src/Infrastructure/Database/Configurations/DealerSettingsConfiguration.cs
@@ -19,12 +19,14 @@ internal sealed class DealerSettingsConfiguration : IEntityTypeConfiguration<Dea
         // provisioning cannot race past an app-level check). PostgreSQL partial
         // unique index ignores rows with NULL HostName so legacy seed rows
         // without a subdomain continue to work.
-        // HasFilter is raw SQL: it bypasses the snake_case naming convention,
-        // so it must reference the physical column name (host_name).
-        builder.HasIndex(s => s.HostName)
-            .IsUnique()
-            .HasFilter("host_name IS NOT NULL")
-            .HasDatabaseName("IX_DealerSettings_HostName_Unique");
+        //
+        // NOTE (saas-custom-domains-followups item 2): this used to declare a
+        // second, duplicate unique index here named "IX_DealerSettings_HostName_Unique"
+        // (PascalCase, predates the project's snake_case index-naming convention).
+        // It was redundant with the "ux_dealer_settings_host_name" index declared
+        // further below (same column, same partial predicate) and has been dropped
+        // via the DropDuplicateDealerSettingsHostNameIndex migration. Keep only the
+        // single HasIndex(s => s.HostName) declaration below.
 
         builder.Property(s => s.DealerName)
             .HasMaxLength(200)

--- a/src/Infrastructure/Migrations/20260717005750_DropDuplicateDealerSettingsHostNameIndex.Designer.cs
+++ b/src/Infrastructure/Migrations/20260717005750_DropDuplicateDealerSettingsHostNameIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717005750_DropDuplicateDealerSettingsHostNameIndex")]
+    partial class DropDuplicateDealerSettingsHostNameIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260717005750_DropDuplicateDealerSettingsHostNameIndex.cs
+++ b/src/Infrastructure/Migrations/20260717005750_DropDuplicateDealerSettingsHostNameIndex.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// saas-custom-domains-followups item 2: drops the redundant, PascalCase-named
+    /// unique index "IX_DealerSettings_HostName_Unique" (originally added by
+    /// AddDealerSettingsHostNameUniqueIndex), which duplicates the snake_case
+    /// "ux_dealer_settings_host_name" index added later by
+    /// AddDealerSettingsHostNameSlugIndexes. Both cover the same column
+    /// (host_name), same uniqueness, and the same partial predicate
+    /// (host_name IS NOT NULL) — keeping only the newer, convention-matching name.
+    ///
+    /// NOTE: `dotnet ef migrations add` produced an empty Up()/Down() for this
+    /// migration — EF Core's migrations differ does not detect a removal when two
+    /// indexes share the exact same (table, columns, unique, filter) signature and
+    /// differ only by name, so the DropIndex/CreateIndex pair below was written by
+    /// hand to match the corresponding CreateIndex/DropIndex in
+    /// AddDealerSettingsHostNameUniqueIndex.
+    /// </remarks>
+    public partial class DropDuplicateDealerSettingsHostNameIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DealerSettings_HostName_Unique",
+                schema: "public",
+                table: "dealer_settings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_DealerSettings_HostName_Unique",
+                schema: "public",
+                table: "dealer_settings",
+                column: "host_name",
+                unique: true,
+                filter: "host_name IS NOT NULL");
+        }
+    }
+}

--- a/tests/ArchitectureTests/Layers/TenantIndexesTests.cs
+++ b/tests/ArchitectureTests/Layers/TenantIndexesTests.cs
@@ -77,6 +77,32 @@ public class TenantIndexesTests : BaseTest
     }
 
     [Fact]
+    public void DealerSettings_Should_Have_Exactly_One_UniqueIndex_On_HostName()
+    {
+        // Arrange — saas-custom-domains-followups item 2: two separately-authored
+        // migrations used to each add a UNIQUE index on HostName under different
+        // names (IX_DealerSettings_HostName_Unique and ux_dealer_settings_host_name).
+        // The redundant one was dropped; only ux_dealer_settings_host_name remains.
+        var model = BuildSnapshotModel();
+        var dealerEntity = model.GetEntityTypes()
+            .Single(t => t.ClrType == typeof(Domain.DealerSettings.DealerSettings));
+
+        // Act
+        var uniqueHostIndexes = dealerEntity.GetIndexes()
+            .Where(i => i.IsUnique
+                && i.Properties.Count == 1
+                && i.Properties[0].Name == nameof(Domain.DealerSettings.DealerSettings.HostName))
+            .ToList();
+
+        // Assert
+        uniqueHostIndexes.Should().ContainSingle(
+            "the redundant IX_DealerSettings_HostName_Unique index was dropped in favor of " +
+            "the single ux_dealer_settings_host_name index — only one UNIQUE index on HostName " +
+            "should remain in the model.");
+        uniqueHostIndexes.Single().GetDatabaseName().Should().Be("ux_dealer_settings_host_name");
+    }
+
+    [Fact]
     public void DealerSettings_Should_Have_Partial_LookupIndex_On_HostName_Where_Active()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Drops the redundant, PascalCase-named unique index `IX_DealerSettings_HostName_Unique` on `dealer_settings.host_name`
- Keeps the snake_case `ux_dealer_settings_host_name` index (same column, same uniqueness, same partial predicate)
- Adds an architecture test asserting exactly one unique index on `HostName`

Part of the `saas-custom-domains-followups` SDD change, item 2.