### PR TITLE
chore(build): use BuildKit cache mount for NuGet restore

### DIFF
--- a/src/Web.Api/Dockerfile
+++ b/src/Web.Api/Dockerfile
@@ -21,15 +21,17 @@ COPY ["src/Application/Application.csproj", "src/Application/"]
 COPY ["src/Domain/Domain.csproj", "src/Domain/"]
 COPY ["src/SharedKernel/SharedKernel.csproj", "src/SharedKernel/"]
 
-# Restore dependencies
-RUN dotnet restore "./src/Web.Api/Web.Api.csproj" --verbosity normal
+# Restore dependencies using BuildKit cache mount
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet restore "./src/Web.Api/Web.Api.csproj" --verbosity normal
 
 # Copy source code
 COPY . .
 
-# Build the application
+# Build the application using BuildKit cache mount
 WORKDIR "/src/src/Web.Api"
-RUN dotnet build "./Web.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build --no-restore
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet build "./Web.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build --no-restore
 
 # Publish the application
 FROM build AS publish


### PR DESCRIPTION
## Summary
- Adds a BuildKit cache mount for the NuGet package cache in Web.Api's Dockerfile
- Speeds up repeated image builds by avoiding a full restore on every build

Unrelated to the HostName index fix in #15 — split out to keep review focus.